### PR TITLE
Addressed damage issue to possibly fix #9

### DIFF
--- a/src/main/resources/assets/yoyos/materials/iron.json
+++ b/src/main/resources/assets/yoyos/materials/iron.json
@@ -4,7 +4,7 @@
     "modifier": 0.85
   },
   "body": {
-    "attack": 40.0,
+    "attack": 4.0,
     "weight": 3.5,
     "durability": 204
   }


### PR DESCRIPTION
Seems that the json had a typo with the value "40.0" for the iron body which is way above others. I'm guessing that it was just a typo and that "4.0" was the actually intended value.